### PR TITLE
grab campus name, not id in search query

### DIFF
--- a/api/routes/queries.js
+++ b/api/routes/queries.js
@@ -16,8 +16,8 @@ const getAllCourses = `SELECT courses.name, campus.name as campus, courses.descr
 				FROM courses, campus WHERE courses.campus = campus.camp_id ORDER BY overall_rating DESC;`
 	
 const insertReview = `INSERT INTO reviews(course_id, user_id, user_comment, workload, enjoyment, difficulty, usefulness, overall) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING course_id, user_id;`
-const searchCoursesByName = `SELECT name, campus, description, overall_rating FROM courses 
-	WHERE name = $1;`
+const searchCoursesByName = `SELECT courses.name, campus.name as campus, courses.description, courses.overall_rating
+	FROM courses, campus WHERE courses.campus = campus.camp_id AND courses.name = $1 ORDER BY overall_rating DESC;`
 
 // Run Queries here 
 exports.test = [


### PR DESCRIPTION
For course search db query, grab the campus name rather than ID so we can display it on the catalog page.